### PR TITLE
Nav rework

### DIFF
--- a/commands/fslocator.go
+++ b/commands/fslocator.go
@@ -252,7 +252,7 @@ func (f *FSLocator) addCompletions() {
 
 func (f *FSLocator) loadDirContents() {
 	defer f.updateCompletions()
-	dir := f.Path()
+	dir := f.dir.Text()
 	if dir == "" {
 		log.Printf("This is odd")
 		return
@@ -263,7 +263,7 @@ func (f *FSLocator) loadDirContents() {
 		return
 	}
 	if err != nil {
-		log.Printf("Unexpected error trying to read directory %s", f.dir.Text())
+		log.Printf("Unexpected error trying to read directory %s: %s", f.dir.Text(), err)
 		return
 	}
 	for _, finfo := range contents {

--- a/editor/split_editor.go
+++ b/editor/split_editor.go
@@ -15,6 +15,21 @@ import (
 	"github.com/nelsam/gxui/themes/basic"
 )
 
+var (
+	splitterBG = gxui.Color{
+		R: .05,
+		G: .05,
+		B: .05,
+		A: 1,
+	}
+	splitterFG = gxui.Color{
+		R: .2,
+		G: .2,
+		B: .2,
+		A: 1,
+	}
+)
+
 type Orienter interface {
 	SetOrientation(gxui.Orientation)
 }
@@ -382,6 +397,8 @@ func NewSplitterBar(viewport gxui.Viewport, theme gxui.Theme) *SplitterBar {
 		vertResize:  glfw.CreateStandardCursor(int(glfw.VResizeCursor)),
 	}
 	s.SplitterBar.Init(s, theme)
+	s.SetBackgroundColor(splitterBG)
+	s.SetForegroundColor(splitterFG)
 	return s
 }
 

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func uiMain(driver gxui.Driver) {
 	editor := editor.New(driver, window, theme, theme.DefaultMonospaceFont())
 	controller.SetEditor(editor)
 
-	projTree := navigator.NewProjectTree(driver, theme)
+	projTree := navigator.NewProjectTree(driver, window, theme)
 	projects := navigator.NewProjectsPane(driver, theme, projTree.Frame())
 
 	nav.Add(projects)

--- a/navigator/directory.go
+++ b/navigator/directory.go
@@ -1,0 +1,187 @@
+// This is free and unencumbered software released into the public
+// domain.  For more information, see <http://unlicense.org> or the
+// accompanying UNLICENSE file.
+
+package navigator
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+
+	"github.com/nelsam/gxui"
+	"github.com/nelsam/gxui/math"
+	"github.com/nelsam/gxui/mixins"
+)
+
+type directory struct {
+	mixins.LinearLayout
+
+	driver gxui.Driver
+	button *treeButton
+	tree   *dirTree
+
+	// length is an atomically updated list of child nodes of
+	// this directory.  Only access via atomics.
+	length int64
+}
+
+func newDirectory(projTree *ProjectTree, path string) *directory {
+	driver := projTree.driver
+	theme := projTree.theme
+
+	button := newTreeButton(driver, theme, filepath.Base(path))
+	tree := newDirTree(projTree, path)
+	tree.SetMargin(math.Spacing{L: 10})
+	d := &directory{
+		driver: driver,
+		button: button,
+		tree:   tree,
+	}
+	d.Init(d, theme)
+	d.AddChild(button)
+	button.OnClick(func(gxui.MouseEvent) {
+		if projTree.tocCtl != nil {
+			projTree.layout.RemoveChild(projTree.tocCtl)
+		}
+		toc := NewTOC(projTree.driver, projTree.theme, path)
+		if projTree.callback != nil {
+			go attachCallback(toc, projTree.callback)
+		}
+		projTree.SetTOC(toc)
+		scrollable := theme.CreateScrollLayout()
+		// Disable horiz scrolling until we can figure out an accurate
+		// way to calculate our width.
+		scrollable.SetScrollAxis(false, true)
+		scrollable.SetChild(toc)
+		projTree.tocCtl = scrollable
+		projTree.layout.AddChild(projTree.tocCtl)
+		projTree.layout.SetChildWeight(projTree.tocCtl, 2)
+		if d.Length() == 0 {
+			return
+		}
+		if d.tree.Attached() {
+			d.button.Collapse()
+			d.RemoveChild(d.tree)
+			return
+		}
+		d.tree.Load()
+		d.button.Expand()
+		d.AddChild(d.tree)
+	})
+	d.reload()
+	return d
+}
+
+func (d *directory) update(path string) {
+	if !strings.HasPrefix(path, d.tree.path) {
+		return
+	}
+	if d.tree.path == filepath.Dir(path) {
+		d.driver.Call(d.reload)
+		return
+	}
+	for _, dir := range d.tree.Dirs() {
+		dir.update(path)
+	}
+}
+
+func (d *directory) ExpandTo(dir string) {
+	if !strings.HasPrefix(dir, d.tree.path) {
+		return
+	}
+	if !d.button.Expanded() {
+		d.button.Click(gxui.MouseEvent{})
+	}
+	for _, child := range d.tree.Dirs() {
+		child.ExpandTo(dir)
+	}
+}
+
+func (d *directory) Length() int64 {
+	return atomic.LoadInt64(&d.length)
+}
+
+func (d *directory) updateExpandable(children int64) {
+	if children == 0 {
+		d.button.SetExpandable(false)
+		return
+	}
+	d.button.SetExpandable(true)
+}
+
+func (d *directory) reload() {
+	finfos, err := ioutil.ReadDir(d.tree.path)
+	if err != nil {
+		log.Printf("Unexpected error reading directory %s: %s", d.tree.path, err)
+		return
+	}
+	defer d.driver.Call(d.Redraw)
+
+	children := int64(0)
+	for _, finfo := range finfos {
+		if finfo.IsDir() {
+			children++
+		}
+	}
+
+	d.updateExpandable(children)
+	atomic.StoreInt64(&d.length, children)
+	if d.tree.Attached() {
+		d.tree.parse(finfos)
+	}
+}
+
+type dirTree struct {
+	mixins.LinearLayout
+
+	projTree *ProjectTree
+	driver   gxui.Driver
+	theme    gxui.Theme
+	path     string
+}
+
+func newDirTree(projTree *ProjectTree, path string) *dirTree {
+	t := &dirTree{
+		projTree: projTree,
+		driver:   projTree.driver,
+		theme:    projTree.theme,
+		path:     path,
+	}
+	t.Init(t, projTree.theme)
+	t.SetDirection(gxui.TopToBottom)
+	return t
+}
+
+func (d *dirTree) Dirs() (dirs []*directory) {
+	for _, c := range d.Children() {
+		dirs = append(dirs, c.Control.(*directory))
+	}
+	return dirs
+}
+
+func (d *dirTree) Load() error {
+	finfos, err := ioutil.ReadDir(d.path)
+	if err != nil {
+		return err
+	}
+	d.parse(finfos)
+	return nil
+}
+
+func (d *dirTree) parse(finfos []os.FileInfo) {
+	d.RemoveAll()
+	for _, finfo := range finfos {
+		if !finfo.IsDir() {
+			continue
+		}
+		if strings.HasPrefix(finfo.Name(), ".") {
+			continue
+		}
+		dir := newDirectory(d.projTree, filepath.Join(d.path, finfo.Name()))
+		d.AddChild(dir)
+	}
+}

--- a/navigator/project_tree.go
+++ b/navigator/project_tree.go
@@ -173,7 +173,9 @@ func (p *ProjectTree) watch() {
 }
 
 func (p *ProjectTree) update(path string) {
-	p.dirs.update(path)
+	p.driver.CallSync(func() {
+		p.dirs.update(path)
+	})
 	toc := p.TOC()
 	if toc != nil && strings.HasPrefix(path, toc.dir) {
 		p.driver.Call(toc.Reload)

--- a/navigator/toc_tree.go
+++ b/navigator/toc_tree.go
@@ -225,6 +225,10 @@ func newName(driver gxui.Driver, theme gxui.Theme, name string, color gxui.Color
 }
 
 func (n *Name) OnSelected(exec func(controller.Executor)) {
+	// OnSelected will often be called in non-UI goroutines because
+	// it's called by resource intensive tasks that shouldn't be
+	// holding up the UI.  However, creating the FileOpener and
+	// setting its location needs to be done on the UI goroutine.
 	var cmd *commands.FileOpener
 	n.driver.CallSync(func() {
 		cmd = commands.NewFileOpener(n.driver, n.theme.(*basic.Theme))

--- a/navigator/tree_button.go
+++ b/navigator/tree_button.go
@@ -1,0 +1,163 @@
+// This is free and unencumbered software released into the public
+// domain.  For more information, see <http://unlicense.org> or the
+// accompanying UNLICENSE file.
+
+package navigator
+
+import (
+	"fmt"
+
+	"github.com/nelsam/gxui"
+	"github.com/nelsam/gxui/math"
+	"github.com/nelsam/gxui/mixins"
+	"github.com/nelsam/gxui/themes/basic"
+)
+
+var preferred = []dropdownCharSet{
+	{
+		expanded:  '▼',
+		collapsed: '►',
+	},
+	{
+		expanded:  '∨',
+		collapsed: '›',
+	},
+	{
+		expanded:  '◊',
+		collapsed: '›',
+	},
+	{
+		expanded:  'v',
+		collapsed: '>',
+	},
+}
+
+type dropdownCharSet struct {
+	expanded, collapsed rune
+}
+
+type treeButton struct {
+	mixins.Button
+
+	driver gxui.Driver
+	theme  *basic.Theme
+	drop   *mixins.Label
+
+	dropSet dropdownCharSet
+}
+
+type indexable interface {
+	Index(r rune) int
+}
+
+func newTreeButton(driver gxui.Driver, theme *basic.Theme, name string) *treeButton {
+	d := &treeButton{
+		driver: driver,
+		theme:  theme,
+		drop:   &mixins.Label{},
+	}
+	d.drop.Init(d.drop, d.theme, d.theme.DefaultMonospaceFont(), dropColor)
+	d.Init(d, theme)
+
+	d.chooseDropSet()
+
+	d.SetDirection(gxui.LeftToRight)
+	d.SetText(name)
+	d.Label().SetColor(dirColor)
+	d.AddChild(d.drop)
+	d.SetPadding(math.Spacing{L: 1, R: 1, B: 1, T: 1})
+	d.SetMargin(math.Spacing{L: 3})
+	d.SetBackgroundBrush(d.theme.ButtonDefaultStyle.Brush)
+	d.OnMouseEnter(func(gxui.MouseEvent) { d.Redraw() })
+	d.OnMouseExit(func(gxui.MouseEvent) { d.Redraw() })
+	d.OnMouseDown(func(gxui.MouseEvent) { d.Redraw() })
+	d.OnMouseUp(func(gxui.MouseEvent) { d.Redraw() })
+	d.OnGainedFocus(d.Redraw)
+	d.OnLostFocus(d.Redraw)
+	return d
+}
+
+func (d *treeButton) chooseDropSet() {
+	font := d.theme.DefaultFont()
+	for _, d.dropSet = range preferred {
+		if font.Index(d.dropSet.collapsed) == 0 {
+			continue
+		}
+		if font.Index(d.dropSet.expanded) == 0 {
+			continue
+		}
+		return
+	}
+}
+
+func (d *treeButton) SetExpandable(expandable bool) {
+	if expandable && d.drop.Text() != "" {
+		return
+	}
+	if !expandable && d.drop.Text() == "" {
+		return
+	}
+	text := ""
+	if expandable {
+		text = fmt.Sprintf(" %c", d.dropSet.collapsed)
+	}
+	d.drop.SetText(text)
+}
+
+func (d *treeButton) Expanded() bool {
+	return d.Expandable() && d.drop.Text() == fmt.Sprintf(" %c", d.dropSet.expanded)
+}
+
+func (d *treeButton) Expandable() bool {
+	return d.drop.Text() != ""
+}
+
+func (d *treeButton) Expand() {
+	d.drop.SetText(fmt.Sprintf(" %c", d.dropSet.expanded))
+}
+
+func (d *treeButton) Collapse() {
+	d.drop.SetText(fmt.Sprintf(" %c", d.dropSet.collapsed))
+}
+
+func (d *treeButton) DesiredSize(min, max math.Size) math.Size {
+	s := d.Button.DesiredSize(min, max)
+	s.W = max.W
+	return s
+}
+
+func (d *treeButton) Style() (s basic.Style) {
+	if d.IsMouseDown(gxui.MouseButtonLeft) && d.IsMouseOver() {
+		return d.theme.ButtonPressedStyle
+	}
+	if d.IsMouseOver() {
+		return d.theme.ButtonOverStyle
+	}
+	return d.theme.ButtonDefaultStyle
+}
+
+func (d *treeButton) Paint(canvas gxui.Canvas) {
+	style := d.Style()
+
+	rect := d.Size().Rect()
+	poly := gxui.Polygon{
+		{Position: math.Point{
+			X: rect.Min.X,
+			Y: rect.Max.Y,
+		}},
+		{Position: math.Point{
+			X: rect.Min.X,
+			Y: rect.Min.Y,
+		}},
+		{Position: math.Point{
+			X: rect.Max.X,
+			Y: rect.Min.Y,
+		}},
+		{Position: math.Point{
+			X: rect.Max.X,
+			Y: rect.Max.Y,
+		}},
+	}
+	canvas.DrawPolygon(poly, gxui.TransparentPen, style.Brush)
+	d.PaintChildren.Paint(canvas)
+}


### PR DESCRIPTION
This reworks the navigation UI.

- The tree is now a custom implementation, based on a linear list full of buttons
- Opening a file now expands the tree to that file and opens that file's package in the TOC
- Changes to the filesystem will be represented in the tree's UI automatically

This still has a (small?) problem in that we can hit our limit of file watches pretty quickly.  Ideally, we would fall back to a polling architecture, but that's not yet in the works.  However, the old code didn't update based on filesystem changes *at all*, so this is still an improvement.

Resolves #50 