### PR TITLE
Override AddPanelAt in TabbedEditor

### DIFF
--- a/editor/tabbed_editor.go
+++ b/editor/tabbed_editor.go
@@ -98,6 +98,11 @@ func (e *TabbedEditor) Add(name string, editor input.Editor) {
 	gxui.SetFocus(editor.(gxui.Focusable))
 }
 
+func (e *TabbedEditor) AddPanelAt(c gxui.Control, n string, i int) {
+	e.PanelHolder.AddPanelAt(c, n, i)
+	e.editors[n] = c.(input.Editor)
+}
+
 func (e *TabbedEditor) Files() []string {
 	files := make([]string, 0, len(e.editors))
 	for file := range e.editors {


### PR DESCRIPTION
Dragging panels between tabbed editors was causing the new tabbed editor
to add the panel as a child without also storing that editor in its map
of available editors.  This meant that the next time something tried to
focus the editor, it would open a second copy of that tab.

This fixes that issue.

Resolves #107

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
