### PR TITLE
Add recovers to the Commander's KeyStroke and KeyPress methods

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -269,6 +269,13 @@ func (c *Commander) Bindable(name string) bind.Bindable {
 
 // KeyPress handles key bindings for c.
 func (c *Commander) KeyPress(event gxui.KeyboardEvent) (consume bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			// TODO: display this in the UI
+			log.Printf("ERR: panic while handling key event: %v", r)
+			log.Printf("Stack trace:\n%s", debug.Stack())
+		}
+	}()
 	editor := c.controller.Editor()
 	if event.Modifier == 0 && event.Key == gxui.KeyEscape {
 		c.box.Clear()
@@ -300,6 +307,13 @@ func (c *Commander) KeyPress(event gxui.KeyboardEvent) (consume bool) {
 }
 
 func (c *Commander) KeyStroke(event gxui.KeyStrokeEvent) (consume bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			// TODO: display this in the UI
+			log.Printf("ERR: panic while handling key stroke: %v", r)
+			log.Printf("Stack trace:\n%s", debug.Stack())
+		}
+	}()
 	if event.Modifier&^gxui.ModShift != 0 {
 		return false
 	}


### PR DESCRIPTION
Since our input handler is overrideable, we shouldn't trust it to never panic.  A single poorly
written input handler plugin could cause data loss in the worst cases, and we'd rather be able
to limp along than lose data.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
