### PR TITLE
Updates to make use of the goroutine-safe textbox

### DIFF
--- a/command/copy_paste.go
+++ b/command/copy_paste.go
@@ -53,7 +53,7 @@ func (c *Copy) Exec(target interface{}) bind.Status {
 
 	selections := editor.Controller().Selections()
 	var buffer bytes.Buffer
-	for i := 0; i < selections.Len(); i++ {
+	for i := 0; i < len(selections); i++ {
 		buffer.WriteString(editor.Controller().SelectionText(i))
 	}
 

--- a/command/find.go
+++ b/command/find.go
@@ -20,7 +20,7 @@ import (
 type SelectionEditor interface {
 	input.Editor
 	Controller() *gxui.TextBoxController
-	Select([]gxui.TextSelection)
+	SelectSlice([]gxui.TextSelection)
 }
 
 type Find struct {
@@ -74,7 +74,7 @@ func (f *Find) Start(control gxui.Control) gxui.Control {
 			pos += count
 			start += (next + length)
 		}
-		f.editor.Select(selections)
+		f.editor.SelectSlice(selections)
 		f.display.SetText(fmt.Sprintf("%s: %d results found", needle, len(selections)))
 	})
 	return f.display

--- a/command/find.go
+++ b/command/find.go
@@ -20,7 +20,7 @@ import (
 type SelectionEditor interface {
 	input.Editor
 	Controller() *gxui.TextBoxController
-	Select(gxui.TextSelectionList)
+	Select([]gxui.TextSelection)
 }
 
 type Find struct {
@@ -62,7 +62,7 @@ func (f *Find) Start(control gxui.Control) gxui.Control {
 		}
 		haystack := f.editor.Text()
 		start := 0
-		var selections gxui.TextSelectionList
+		var selections []gxui.TextSelection
 
 		count := utf8.RuneCountInString(needle)
 		length := len(needle)

--- a/command/find_regex.go
+++ b/command/find_regex.go
@@ -65,7 +65,7 @@ func (f *RegexFind) Start(control gxui.Control) gxui.Control {
 
 			}
 		}
-		f.editor.Select(selections)
+		f.editor.SelectSlice(selections)
 		f.display.SetText(fmt.Sprintf("%s: %d results found", needle, len(selections)))
 	})
 	return f.display

--- a/command/find_regex.go
+++ b/command/find_regex.go
@@ -54,7 +54,7 @@ func (f *RegexFind) Start(control gxui.Control) gxui.Control {
 			return
 		}
 
-		var selections gxui.TextSelectionList
+		var selections []gxui.TextSelection
 
 		for _, indexes := range arr {
 			for i := 0; i < len(indexes); i += 2 {

--- a/command/input/handler.go
+++ b/command/input/handler.go
@@ -186,7 +186,7 @@ func (e *Handler) HandleEvent(focused input.Editor, ev gxui.KeyboardEvent) {
 		}
 	case gxui.KeyBackspace, gxui.KeyDelete:
 		var edits []input.Edit
-		for _, s := range editor.Controller().Selections() {
+		for _, s := range editor.Controller().SelectionSlice() {
 			if s.Start() < 0 {
 				continue
 			}
@@ -216,7 +216,7 @@ func (e *Handler) HandleInput(focused input.Editor, ev gxui.KeyStrokeEvent) {
 	editor := focused.(*editor.CodeEditor)
 	ctrl := editor.Controller()
 	var edits []input.Edit
-	for _, s := range editor.Controller().Selections() {
+	for _, s := range editor.Controller().SelectionSlice() {
 		edits = append(edits, input.Edit{
 			At:  s.Start(),
 			Old: ctrl.TextRunes()[s.Start():s.End()],

--- a/command/replace.go
+++ b/command/replace.go
@@ -61,7 +61,7 @@ func (f *Replace) Start(control gxui.Control) gxui.Control {
 		}
 		haystack := f.editor.Text()
 		start := 0
-		var selections gxui.TextSelectionList
+		var selections []gxui.TextSelection
 
 		count := utf8.RuneCountInString(needle)
 		length := len(needle)
@@ -92,8 +92,8 @@ func (f *Replace) Start(control gxui.Control) gxui.Control {
 			f.edits = []input.Edit{}
 			selections := f.editor.Controller().Selections()
 
-			for i := selections.Len(); i != 0; i-- {
-				begin, end := selections.Interval(i - 1)
+			for i := len(selections) - 1; i >= 0; i-- {
+				begin, end := selections[i].Start(), selections[i].End()
 				str := []rune(f.editor.Text())[begin:end]
 				f.edits = append(f.edits, input.Edit{
 					At:  int(begin),

--- a/command/replace.go
+++ b/command/replace.go
@@ -73,7 +73,7 @@ func (f *Replace) Start(control gxui.Control) gxui.Control {
 			pos += count
 			start += (next + length)
 		}
-		f.editor.Select(selections)
+		f.editor.SelectSlice(selections)
 		f.status.SetText(fmt.Sprintf("%s: %d results found", needle, len(selections)))
 	})
 	f.find.OnKeyPress(func(ev gxui.KeyboardEvent) {
@@ -90,7 +90,7 @@ func (f *Replace) Start(control gxui.Control) gxui.Control {
 		switch ev.Key {
 		case gxui.KeyEnter:
 			f.edits = []input.Edit{}
-			selections := f.editor.Controller().Selections()
+			selections := f.editor.Controller().SelectionSlice()
 
 			for i := len(selections) - 1; i >= 0; i-- {
 				begin, end := selections[i].Start(), selections[i].End()

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -38,7 +38,7 @@ type CodeEditor struct {
 
 	watcher fsw.Watcher
 
-	selections      gxui.TextSelectionList
+	selections      []gxui.TextSelection
 	scrollPositions math.Point
 	layers          []input.SyntaxLayer
 
@@ -88,10 +88,11 @@ func (e *CodeEditor) SetCarets(carets ...int) {
 			e.Controller().ClearSelections()
 			return
 		}
-		e.Controller().SetCaret(carets[0])
-		for _, c := range carets[1:] {
-			e.Controller().AddCaret(c)
+		var sel []gxui.TextSelection
+		for _, c := range carets {
+			sel = append(sel, gxui.CreateTextSelection(c, c, true))
 		}
+		e.Controller().SetSelections(sel)
 	})
 }
 
@@ -222,7 +223,9 @@ func (e *CodeEditor) load(headerText string) {
 			return
 		}
 		e.SetText(newText)
-		e.restorePositions()
+		if len(e.selections) > 0 {
+			e.restorePositions()
+		}
 	})
 }
 

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -78,22 +78,15 @@ func (e *CodeEditor) Carets() []int {
 }
 
 func (e *CodeEditor) SetCarets(carets ...int) {
-	// The following is added to the UI call stack because *some* calls to
-	// SetCarets will happen in a UI call while there are still SetCarets
-	// calls in the UI stack.  This happens especially in the case where
-	// a new file has been opened, which adds SetCarets([0]) as a call in
-	// the UI call stack.
-	e.driver.Call(func() {
-		if len(carets) == 0 {
-			e.Controller().ClearSelections()
-			return
-		}
-		var sel []gxui.TextSelection
-		for _, c := range carets {
-			sel = append(sel, gxui.CreateTextSelection(c, c, true))
-		}
-		e.Controller().SetSelections(sel)
-	})
+	if len(carets) == 0 {
+		e.Controller().ClearSelections()
+		return
+	}
+	var sel []gxui.TextSelection
+	for _, c := range carets {
+		sel = append(sel, gxui.CreateTextSelection(c, c, true))
+	}
+	e.Controller().SetSelections(sel)
 }
 
 func (e *CodeEditor) OnRename(callback func(newPath string)) {

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -290,7 +290,7 @@ func (e *CodeEditor) Paint(c gxui.Canvas) {
 }
 
 func (e *CodeEditor) storePositions() {
-	e.selections = e.Controller().Selections()
+	e.selections = e.Controller().SelectionSlice()
 	e.scrollPositions = math.Point{
 		X: e.HorizOffset(),
 		Y: e.ScrollOffset(),

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func init() {
 			"unsaved work.",
 		Run: func(cmd *cobra.Command, args []string) {
 			files = args
-			gl.StartDriver(uiMain)
+			gl.StartDriver(uiMain, gl.Debug())
 		},
 	}
 }

--- a/navigator/project_tree.go
+++ b/navigator/project_tree.go
@@ -7,6 +7,7 @@ package navigator
 import (
 	"fmt"
 	"go/token"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -189,6 +190,9 @@ func (p *ProjectTree) startWatch(root string) {
 func (p *ProjectTree) watch() {
 	for {
 		e, err := p.watcher.Next()
+		if err == io.EOF {
+			return
+		}
 		if err != nil {
 			log.Printf("ProjectTree: Error from watcher: %s", err)
 		}

--- a/plugin/comments/toggle.go
+++ b/plugin/comments/toggle.go
@@ -22,7 +22,7 @@ type Editor interface {
 }
 
 type Selecter interface {
-	Selections() gxui.TextSelectionList
+	Selections() []gxui.TextSelection
 }
 
 type Toggle struct {
@@ -75,8 +75,8 @@ func (t *Toggle) Exec() error {
 	selections := t.selecter.Selections()
 
 	var edits []input.Edit
-	for i := selections.Len(); i != 0; i-- {
-		begin, end := selections.Interval(i - 1)
+	for i := len(selections) - 1; i >= 0; i-- {
+		begin, end := selections[i].Start(), selections[i].End()
 		str := t.editor.Text()[begin:end]
 		re, replace := regexpReplace(str)
 		newstr := re.ReplaceAllString(str, replace)

--- a/plugin/comments/toggle.go
+++ b/plugin/comments/toggle.go
@@ -22,7 +22,7 @@ type Editor interface {
 }
 
 type Selecter interface {
-	Selections() []gxui.TextSelection
+	SelectionSlice() []gxui.TextSelection
 }
 
 type Toggle struct {
@@ -72,7 +72,7 @@ func (t *Toggle) Store(target interface{}) bind.Status {
 }
 
 func (t *Toggle) Exec() error {
-	selections := t.selecter.Selections()
+	selections := t.selecter.SelectionSlice()
 
 	var edits []input.Edit
 	for i := len(selections) - 1; i >= 0; i-- {


### PR DESCRIPTION
This uses new code from nelsam/gxui#8 that makes access to the TextBoxController goroutine-safe.  It will not pass CI until the gxui PR is merged.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [x] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
