### PR TITLE
commands/history: make history persist when changing files

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nelsam/gxui/themes/basic"
 	"github.com/nelsam/vidar/command/caret"
 	"github.com/nelsam/vidar/command/focus"
+	"github.com/nelsam/vidar/command/history"
 	"github.com/nelsam/vidar/command/project"
 	"github.com/nelsam/vidar/commander/bind"
 	"github.com/nelsam/vidar/plugin/command"
@@ -30,5 +31,6 @@ func Bindables(cmdr command.Commander, driver gxui.Driver, theme *basic.Theme) [
 		ViewHook{},
 		NavHook{Commander: cmdr},
 	)
+	b = append(b, history.Bindables(cmdr, driver, theme)...)
 	return b
 }

--- a/command/edit.go
+++ b/command/edit.go
@@ -7,7 +7,6 @@ package command
 import (
 	"github.com/nelsam/gxui"
 	"github.com/nelsam/gxui/themes/basic"
-	"github.com/nelsam/vidar/command/history"
 	"github.com/nelsam/vidar/commander/bind"
 )
 
@@ -25,9 +24,7 @@ func (h EditHook) OpName() string {
 }
 
 func (h EditHook) FileBindables(string) []bind.Bindable {
-	history, undo, redo := history.New(h.Theme)
 	return []bind.Bindable{
-		history, undo, redo,
 		NewSelectAll(),
 		NewFind(h.Driver, h.Theme),
 		NewRegexFind(h.Driver, h.Theme),

--- a/command/history/history.go
+++ b/command/history/history.go
@@ -24,30 +24,35 @@ func (n *node) push(e input.Edit) *node {
 	return next
 }
 
+// Bindables returns the slice of bind.Bindable types that is implemented
+// by this package.
 func Bindables(_ command.Commander, _ gxui.Driver, theme *basic.Theme) []bind.Bindable {
 	h := History{current: &node{}, all: make(map[string]*node)}
 	onOpen := OnOpen{theme: theme}
 	return []bind.Bindable{&h, &onOpen}
 }
 
+// History keeps track of change history for a file.
 type History struct {
-	current     *node
-	currentPath string
-	skip        []input.Edit
+	current *node
+	skip    []input.Edit
 
 	all map[string]*node
 }
 
+// Name returns the name of h
 func (h *History) Name() string {
 	return "history"
 }
 
+// OpNames returns the name of bind.Op types that
+// h needs to bind to.
 func (h *History) OpNames() []string {
 	return []string{"input-handler", "focus-location"}
 }
 
-func (h *History) Init(e input.Editor, _ []rune) {
-}
+// Init implements input.ChangeHook
+func (h *History) Init(input.Editor, []rune) {}
 
 func (h *History) shouldSkip(e input.Edit) bool {
 	if len(h.skip) == 0 {
@@ -104,17 +109,19 @@ func (h *History) FastForward(branch uint) input.Edit {
 	return h.current.edit
 }
 
+// Apply is unused on history - recording the changes is all
+// that is needed.
 func (h *History) Apply(input.Editor) error { return nil }
 
-// FileBindables is here to trigger when the file path changes,
-// like when a new file is opened or a tab is switched.
-func (h *History) FileBindables(path string) []bind.Bindable {
-	h.all[h.currentPath] = h.current
-	h.currentPath = path
+// FileChanged updates the current history when the focused
+// file is changed.
+func (h *History) FileChanged(oldPath, newPath string) {
+	if oldPath != "" {
+		h.all[oldPath] = h.current
+	}
 	h.current = &node{}
-	if n, ok := h.all[h.currentPath]; ok {
+	if n, ok := h.all[newPath]; ok {
 		h.current = n
 	}
 	h.skip = nil
-	return nil
 }

--- a/command/history/history_test.go
+++ b/command/history/history_test.go
@@ -1,0 +1,16 @@
+// This is free and unencumbered software released into the public
+// domain.  For more information, see <http://unlicense.org> or the
+// accompanying UNLICENSE file.
+
+package history_test
+
+import (
+	"github.com/nelsam/vidar/command/focus"
+	"github.com/nelsam/vidar/command/history"
+	"github.com/nelsam/vidar/command/input"
+)
+
+var (
+	_ input.ChangeHook  = &history.History{}
+	_ focus.FileChanger = &history.History{}
+)

--- a/command/history/undo_redo.go
+++ b/command/history/undo_redo.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/nelsam/gxui"
+	"github.com/nelsam/gxui/themes/basic"
 	"github.com/nelsam/vidar/commander/bind"
 	"github.com/nelsam/vidar/commander/input"
 	"github.com/nelsam/vidar/plugin/status"
@@ -17,11 +18,31 @@ type Applier interface {
 	Apply(input.Editor, ...input.Edit)
 }
 
+type OnOpen struct {
+	theme *basic.Theme
+}
+
+func (o OnOpen) Name() string {
+	return "undo-redo-open-hook"
+}
+
+func (o OnOpen) OpName() string {
+	return "focus-location"
+}
+
+func (o OnOpen) FileBindables(string) []bind.Bindable {
+	u := &Undo{}
+	u.Theme = o.theme
+	r := &Redo{}
+	r.Theme = o.theme
+	return []bind.Bindable{u, r}
+}
+
 // An Undo is a command which undoes an action.
 type Undo struct {
 	status.General
-	history *History
 
+	history *History
 	applier Applier
 	editor  input.Editor
 }
@@ -42,18 +63,21 @@ func (u *Undo) Defaults() []fmt.Stringer {
 }
 
 func (u *Undo) Reset() {
+	u.history = nil
 	u.applier = nil
 	u.editor = nil
 }
 
 func (u *Undo) Store(target interface{}) bind.Status {
 	switch src := target.(type) {
+	case *History:
+		u.history = src
 	case Applier:
 		u.applier = src
 	case input.Editor:
 		u.editor = src
 	}
-	if u.applier != nil && u.editor != nil {
+	if u.applier != nil && u.editor != nil && u.history != nil {
 		return bind.Done
 	}
 	return bind.Waiting
@@ -72,8 +96,8 @@ func (u *Undo) Exec() error {
 // A Redo is a command which redoes an action.
 type Redo struct {
 	status.General
-	history *History
 
+	history *History
 	editor  input.Editor
 	applier Applier
 }
@@ -94,18 +118,21 @@ func (r *Redo) Defaults() []fmt.Stringer {
 }
 
 func (r *Redo) Reset() {
+	r.history = nil
 	r.editor = nil
 	r.applier = nil
 }
 
 func (r *Redo) Store(target interface{}) bind.Status {
 	switch src := target.(type) {
+	case *History:
+		r.history = src
 	case Applier:
 		r.applier = src
 	case input.Editor:
 		r.editor = src
 	}
-	if r.applier != nil && r.editor != nil {
+	if r.applier != nil && r.editor != nil && r.history != nil {
 		return bind.Done
 	}
 	return bind.Waiting


### PR DESCRIPTION
History used to persist when it was stored directly on the `CodeEditor`, but updates to decouple the `CodeEditor` from the commands have lost that.  This fixes the history type to persist at the core of vidar and understand file changes.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [x] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
