### PR TITLE
Add lock for loadDirContents

### DIFF
--- a/command/fs/locator.go
+++ b/command/fs/locator.go
@@ -279,8 +279,12 @@ func (f *Locator) addCompletions(completions []gxui.Label) {
 }
 
 func (f *Locator) loadDirContents() {
-	defer f.updateCompletions()
 
+	f.lock.Lock()
+	defer func() {
+		f.lock.Unlock()
+		f.updateCompletions()
+	}()
 	f.files = nil
 	dir := f.dir.Text()
 	if dir == "" {


### PR DESCRIPTION
After quick clicking on backspace when open file I got report in race log, it's fix for it.

> Write at 0x00c0422e4320 by goroutine 103:
>   github.com/nelsam/vidar/command/fs.(*Locator).loadDirContents()
>       E:/gopath/src/github.com/nelsam/vidar/command/fs/locator.go:284 +0x99
> 
> Previous write at 0x00c0422e4320 by goroutine 104:
>   github.com/nelsam/vidar/command/fs.(*Locator).loadDirContents()
>       E:/gopath/src/github.com/nelsam/vidar/command/fs/locator.go:303 +0x301

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [x] Windows
* [ ] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
