### PR TITLE
Don't destroy not empty editor

### DIFF
--- a/editor/tabbed_editor.go
+++ b/editor/tabbed_editor.go
@@ -33,6 +33,7 @@ type TabbedEditor struct {
 	theme       *basic.Theme
 	syntaxTheme theme.Theme
 	font        gxui.Font
+	cur         string
 }
 
 func NewTabbedEditor(driver gxui.Driver, cmdr Commander, theme *basic.Theme, syntaxTheme theme.Theme, font gxui.Font) *TabbedEditor {
@@ -117,9 +118,18 @@ func (e *TabbedEditor) Editors() uint {
 
 func (e *TabbedEditor) CreatePanelTab() mixins.PanelTab {
 	tab := basic.CreatePanelTab(e.theme)
+	tab.OnMouseDown(func(ev gxui.MouseEvent) {
+		if e.CurrentEditor() != nil {
+			e.cur = e.CurrentEditor().Filepath()
+		}
+	})
 	tab.OnMouseUp(func(gxui.MouseEvent) {
 		if e.CurrentEditor() == nil {
-			e.purgeSelf()
+			if len(e.editors) == 1 {
+				e.purgeSelf()
+			} else {
+				delete(e.editors, e.cur)
+			}
 			return
 		}
 		opener := e.cmdr.Bindable("focus-location").(Opener)


### PR DESCRIPTION
Workaround for #116, if editor contains several tabs it shouldn't been destroyed. 

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [x] Windows
* [ ] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
