### PR TITLE
plugin/gocode: actually close when there are no results to apply

### DIFF
--- a/plugin/gocode/list.go
+++ b/plugin/gocode/list.go
@@ -91,6 +91,7 @@ func (s *suggestionList) show(ctx context.Context, pos int) int {
 	}
 
 	s.driver.CallSync(func() {
+		// TODO: This doesn't always create a large enough box; it needs to be fixed.
 		longest := s.adapter.Sort(runes[start:pos])
 		if s.adapter.Len() == 0 {
 			return


### PR DESCRIPTION
Prior to this, there were cases where gocode would have an empty list and try to apply a nonexistent code suggestion.  We've prevented these types of issues from crashing the editor, but we didn't fix the plugin (partly because we wanted to use the plugin to verify the fixes in the editor).  These are now fixed.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
