### PR TITLE
plugin/gosyntax: lock access to the syntax highlighter

### DIFF
--- a/syntax/builtin_test.go
+++ b/syntax/builtin_test.go
@@ -7,15 +7,19 @@ package syntax_test
 import (
 	"testing"
 
-	"github.com/a8m/expect"
+	"github.com/apoydence/onpar"
+	"github.com/apoydence/onpar/expect"
+	. "github.com/apoydence/onpar/matchers"
+	"github.com/nelsam/vidar/commander/input"
 	"github.com/nelsam/vidar/syntax"
 	"github.com/nelsam/vidar/theme"
 )
 
 func TestBuiltins(t *testing.T) {
-	expect := expect.New(t)
+	o := onpar.New()
+	defer o.Run(t)
 
-	src := `
+	const src = `
 	package foo
 
 	func foo() {
@@ -40,38 +44,47 @@ func TestBuiltins(t *testing.T) {
 		v := nil
 
 		panic("foo")
-	}
-	`
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil().Else.FailNow()
+	}`
 
-	layers := s.Layers()
+	o.BeforeEach(func(t *testing.T) (expect.Expectation, []input.SyntaxLayer) {
+		expect := expect.New(t)
 
-	builtins := findLayer(theme.Builtin, layers)
-	expect(builtins.Spans).To.Have.Len(15).Else.FailNow()
+		s := syntax.New()
+		err := s.Parse(src)
+		expect(err).To(BeNil())
 
-	expect(builtins.Spans[0]).To.Pass(position{src: src, match: "recover"})
-	expect(builtins.Spans[1]).To.Pass(position{src: src, match: "append"})
-	expect(builtins.Spans[2]).To.Pass(position{src: src, match: "cap"})
-	expect(builtins.Spans[3]).To.Pass(position{src: src, match: "copy"})
-	expect(builtins.Spans[4]).To.Pass(position{src: src, match: "delete"})
-	expect(builtins.Spans[5]).To.Pass(position{src: src, match: "len"})
-	expect(builtins.Spans[6]).To.Pass(position{src: src, match: "new"})
-	expect(builtins.Spans[7]).To.Pass(position{src: src, match: "print"})
-	expect(builtins.Spans[8]).To.Pass(position{src: src, match: "println"})
-	expect(builtins.Spans[9]).To.Pass(position{src: src, match: "make"})
-	expect(builtins.Spans[10]).To.Pass(position{src: src, match: "close"})
-	expect(builtins.Spans[11]).To.Pass(position{src: src, match: "complex"})
-	expect(builtins.Spans[12]).To.Pass(position{src: src, match: "imag"})
-	expect(builtins.Spans[13]).To.Pass(position{src: src, match: "real"})
-	expect(builtins.Spans[14]).To.Pass(position{src: src, match: "panic"})
+		layers := s.Layers()
 
-	nils := findLayer(theme.Nil, layers)
-	expect(nils.Spans).To.Have.Len(1).Else.FailNow()
-	expect(nils.Spans[0]).To.Pass(position{src: src, match: "nil"})
+		return expect, layers
+	})
 
-	// Test that we're not highlighting these as both idents and builtins.
-	idents := findLayer(theme.Ident, layers)
-	expect(idents.Spans).To.Have.Len(6)
+	o.Spec("it highlights the expected builtins", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+		builtins := findLayer(theme.Builtin, layers)
+		expect(builtins.Spans[0]).To(matchPosition{src: src, match: "recover"})
+		expect(builtins.Spans[1]).To(matchPosition{src: src, match: "append"})
+		expect(builtins.Spans[2]).To(matchPosition{src: src, match: "cap"})
+		expect(builtins.Spans[3]).To(matchPosition{src: src, match: "copy"})
+		expect(builtins.Spans[4]).To(matchPosition{src: src, match: "delete"})
+		expect(builtins.Spans[5]).To(matchPosition{src: src, match: "len"})
+		expect(builtins.Spans[6]).To(matchPosition{src: src, match: "new"})
+		expect(builtins.Spans[7]).To(matchPosition{src: src, match: "print"})
+		expect(builtins.Spans[8]).To(matchPosition{src: src, match: "println"})
+		expect(builtins.Spans[9]).To(matchPosition{src: src, match: "make"})
+		expect(builtins.Spans[10]).To(matchPosition{src: src, match: "close"})
+		expect(builtins.Spans[11]).To(matchPosition{src: src, match: "complex"})
+		expect(builtins.Spans[12]).To(matchPosition{src: src, match: "imag"})
+		expect(builtins.Spans[13]).To(matchPosition{src: src, match: "real"})
+		expect(builtins.Spans[14]).To(matchPosition{src: src, match: "panic"})
+	})
+
+	o.Spec("it highlights nil", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+		nils := findLayer(theme.Nil, layers)
+		expect(nils.Spans).To(HaveLen(1))
+		expect(nils.Spans[0]).To(matchPosition{src: src, match: "nil"})
+	})
+
+	o.Spec("it does not highlight builtins as idents", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+		idents := findLayer(theme.Ident, layers)
+		expect(idents.Spans).To(HaveLen(6))
+	})
 }

--- a/syntax/builtin_test.go
+++ b/syntax/builtin_test.go
@@ -48,7 +48,7 @@ func TestBuiltins(t *testing.T) {
 
 	layers := s.Layers()
 
-	builtins := layers[theme.Builtin]
+	builtins := findLayer(theme.Builtin, layers)
 	expect(builtins.Spans).To.Have.Len(15).Else.FailNow()
 
 	expect(builtins.Spans[0]).To.Pass(position{src: src, match: "recover"})
@@ -67,11 +67,11 @@ func TestBuiltins(t *testing.T) {
 	expect(builtins.Spans[13]).To.Pass(position{src: src, match: "real"})
 	expect(builtins.Spans[14]).To.Pass(position{src: src, match: "panic"})
 
-	nils := layers[theme.Nil]
+	nils := findLayer(theme.Nil, layers)
 	expect(nils.Spans).To.Have.Len(1).Else.FailNow()
 	expect(nils.Spans[0]).To.Pass(position{src: src, match: "nil"})
 
 	// Test that we're not highlighting these as both idents and builtins.
-	idents := layers[theme.Ident]
+	idents := findLayer(theme.Ident, layers)
 	expect(idents.Spans).To.Have.Len(6)
 }

--- a/syntax/decl_test.go
+++ b/syntax/decl_test.go
@@ -9,9 +9,19 @@ import (
 	"testing"
 
 	"github.com/a8m/expect"
+	"github.com/nelsam/vidar/commander/input"
 	"github.com/nelsam/vidar/syntax"
 	"github.com/nelsam/vidar/theme"
 )
+
+func findLayer(c theme.LanguageConstruct, l []input.SyntaxLayer) input.SyntaxLayer {
+	for _, layer := range l {
+		if layer.Construct == c {
+			return layer
+		}
+	}
+	return input.SyntaxLayer{}
+}
 
 func TestDecl(t *testing.T) {
 	t.Run("Gen", GenDecl)
@@ -40,15 +50,15 @@ var Foo string
 	layers := s.Layers()
 	expect(layers).To.Have.Len(3)
 
-	keywords := layers[theme.Keyword]
-	expect(keywords.Spans).To.Have.Len(2)
+	keywords := findLayer(theme.Keyword, layers)
+	expect(keywords.Spans).To.Have.Len(2).Else.FailNow()
 	expect(keywords.Spans[1]).To.Pass(position{src: src, match: "var"})
 
-	comments := layers[theme.Comment]
+	comments := findLayer(theme.Comment, layers)
 	expect(comments.Spans).To.Have.Len(1)
 	expect(comments.Spans[0]).To.Pass(position{src: src, match: "// Foo is a thing"})
 
-	typs := layers[theme.Type]
+	typs := findLayer(theme.Type, layers)
 	expect(typs.Spans).To.Have.Len(1)
 	expect(typs.Spans[0]).To.Pass(position{src: src, match: "string"})
 }
@@ -71,16 +81,16 @@ var (
 	layers := s.Layers()
 	expect(layers).To.Have.Len(3)
 
-	keywords := layers[theme.Keyword]
+	keywords := findLayer(theme.Keyword, layers)
 	expect(keywords.Spans).To.Have.Len(2)
 	expect(keywords.Spans[1]).To.Pass(position{src: src, match: "var"})
 
-	parens := layers[theme.ScopePair]
-	expect(parens.Spans).To.Have.Len(2)
+	parens := findLayer(theme.ScopePair, layers)
+	expect(parens.Spans).To.Have.Len(2).Else.FailNow()
 	expect(parens.Spans[0]).To.Pass(position{src: src, match: "("})
 	expect(parens.Spans[1]).To.Pass(position{src: src, match: ")"})
 
-	typs := layers[theme.Type]
+	typs := findLayer(theme.Type, layers)
 	expect(typs.Spans).To.Have.Len(2)
 	expect(typs.Spans[0]).To.Pass(position{src: src, match: "string"})
 	expect(typs.Spans[1]).To.Pass(position{src: src, match: "int"})
@@ -103,24 +113,24 @@ func Foo(bar string) int {
 	layers := s.Layers()
 	expect(layers).To.Have.Len(5)
 
-	keywords := layers[theme.Keyword]
+	keywords := findLayer(theme.Keyword, layers)
 	expect(keywords.Spans).To.Have.Len(3)
 	expect(keywords.Spans[1]).To.Pass(position{src: src, match: "func"})
 	expect(keywords.Spans[2]).To.Pass(position{src: src, match: "return"})
 
-	parens := layers[theme.ScopePair]
+	parens := findLayer(theme.ScopePair, layers)
 	expect(parens.Spans).To.Have.Len(4)
 	expect(parens.Spans[0]).To.Pass(position{src: src, match: "("})
 	expect(parens.Spans[1]).To.Pass(position{src: src, match: ")"})
 	expect(parens.Spans[2]).To.Pass(position{src: src, match: "{"})
 	expect(parens.Spans[3]).To.Pass(position{src: src, match: "}"})
 
-	typs := layers[theme.Type]
+	typs := findLayer(theme.Type, layers)
 	expect(typs.Spans).To.Have.Len(2)
 	expect(typs.Spans[0]).To.Pass(position{src: src, match: "string"})
 	expect(typs.Spans[1]).To.Pass(position{src: src, match: "int"})
 
-	ints := layers[theme.Num]
+	ints := findLayer(theme.Num, layers)
 	expect(ints.Spans).To.Have.Len(1)
 	expect(ints.Spans[0]).To.Pass(position{src: src, match: "0"})
 }
@@ -140,7 +150,7 @@ package foo
 	layers := s.Layers()
 	expect(layers).To.Have.Len(2)
 
-	bad := layers[theme.Bad]
+	bad := findLayer(theme.Bad, layers)
 	expect(bad.Spans).To.Have.Len(1)
 	expectedStart := strings.Index(src, "10")
 	expect(bad.Spans[0].Start).To.Equal(expectedStart)

--- a/syntax/general_test.go
+++ b/syntax/general_test.go
@@ -7,54 +7,79 @@ package syntax_test
 import (
 	"testing"
 
-	"github.com/a8m/expect"
+	"github.com/apoydence/onpar"
+	"github.com/apoydence/onpar/expect"
+	. "github.com/apoydence/onpar/matchers"
+	"github.com/nelsam/vidar/commander/input"
 	"github.com/nelsam/vidar/syntax"
 	"github.com/nelsam/vidar/theme"
 )
 
 func TestUnicode(t *testing.T) {
-	expect := expect.New(t)
+	o := onpar.New()
+	defer o.Run(t)
 
-	src := `
-package foo
+	const src = `
+	package foo
+	
+	func µ() string {
+		var þ = "Ωð"
+		return þ
+	}`
 
-func µ() string {
-	var þ = "Ωð"
-	return þ
-}
-`
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil()
+	o.BeforeEach(func(t *testing.T) (expect.Expectation, []input.SyntaxLayer) {
+		expect := expect.New(t)
 
-	layers := s.Layers()
-	keywords := findLayer(theme.Keyword, layers)
-	expect(keywords.Spans).To.Have.Len(4)
-	expect(keywords.Spans[2]).To.Pass(position{src: src, match: "var"})
-	expect(keywords.Spans[3]).To.Pass(position{src: src, match: "return"})
+		s := syntax.New()
+		err := s.Parse(src)
+		expect(err).To(BeNil())
+		layers := s.Layers()
 
-	strings := findLayer(theme.String, layers)
-	expect(strings.Spans).To.Have.Len(1)
-	expect(strings.Spans[0]).To.Pass(position{src: src, match: `"Ωð"`})
+		return expect, layers
+	})
+
+	o.Spec("it sets keyword spans to the correct index with unicode characters", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+		keywords := findLayer(theme.Keyword, layers)
+		expect(keywords.Spans).To(HaveLen(4))
+		expect(keywords.Spans[2]).To(matchPosition{src: src, match: "var"})
+		expect(keywords.Spans[3]).To(matchPosition{src: src, match: "return"})
+	})
+
+	o.Spec("it sets string spans to the correct index with unicode characters", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+		strings := findLayer(theme.String, layers)
+		expect(strings.Spans).To(HaveLen(1))
+		expect(strings.Spans[0]).To(matchPosition{src: src, match: `"Ωð"`})
+	})
 }
 
 func TestPackageDocs(t *testing.T) {
-	expect := expect.New(t)
+	o := onpar.New()
+	defer o.Run(t)
 
-	src := `
+	// Note: leading whitespace does affect the test, so leave this unindented.
+	const src = `
 // Package foo does stuff.
 // It is also a thing.
-package foo
-`
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil()
-	layers := s.Layers()
-	expect(layers).To.Have.Len(2)
+package foo`
 
-	comments := findLayer(theme.Comment, layers)
-	expect(comments.Spans).To.Have.Len(1)
-	comment := "// Package foo does stuff.\n" +
-		"// It is also a thing."
-	expect(comments.Spans[0]).To.Pass(position{src: src, match: comment})
+	o.BeforeEach(func(t *testing.T) (expect.Expectation, []input.SyntaxLayer) {
+		expect := expect.New(t)
+
+		s := syntax.New()
+		err := s.Parse(src)
+		expect(err).To(BeNil())
+
+		layers := s.Layers()
+		expect(layers).To(HaveLen(2))
+
+		return expect, layers
+	})
+
+	o.Spec("it highlights package docs", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+		comments := findLayer(theme.Comment, layers)
+		expect(comments.Spans).To(HaveLen(1))
+		comment := "// Package foo does stuff.\n" +
+			"// It is also a thing."
+		expect(comments.Spans[0]).To(matchPosition{src: src, match: comment})
+	})
 }

--- a/syntax/general_test.go
+++ b/syntax/general_test.go
@@ -28,12 +28,12 @@ func µ() string {
 	expect(err).To.Be.Nil()
 
 	layers := s.Layers()
-	keywords := layers[theme.Keyword]
+	keywords := findLayer(theme.Keyword, layers)
 	expect(keywords.Spans).To.Have.Len(4)
 	expect(keywords.Spans[2]).To.Pass(position{src: src, match: "var"})
 	expect(keywords.Spans[3]).To.Pass(position{src: src, match: "return"})
 
-	strings := layers[theme.String]
+	strings := findLayer(theme.String, layers)
 	expect(strings.Spans).To.Have.Len(1)
 	expect(strings.Spans[0]).To.Pass(position{src: src, match: `"Ωð"`})
 }
@@ -52,7 +52,7 @@ package foo
 	layers := s.Layers()
 	expect(layers).To.Have.Len(2)
 
-	comments := layers[theme.Comment]
+	comments := findLayer(theme.Comment, layers)
 	expect(comments.Spans).To.Have.Len(1)
 	comment := "// Package foo does stuff.\n" +
 		"// It is also a thing."

--- a/syntax/keywords_test.go
+++ b/syntax/keywords_test.go
@@ -5,17 +5,22 @@
 package syntax_test
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/a8m/expect"
+	"github.com/apoydence/onpar"
+	"github.com/apoydence/onpar/expect"
+	. "github.com/apoydence/onpar/matchers"
+	"github.com/nelsam/vidar/commander/input"
 	"github.com/nelsam/vidar/syntax"
 	"github.com/nelsam/vidar/theme"
 )
 
 func TestKeywords(t *testing.T) {
-	expect := expect.New(t)
+	o := onpar.New()
+	defer o.Run(t)
 
-	src := `
+	const src = `
 	package foo
 
 	import "time"
@@ -60,54 +65,66 @@ FOO:
 		case <-time.After(time.Second):
 		default:
 		}
+	}`
+
+	o.BeforeEach(func(t *testing.T) (expect.Expectation, []input.SyntaxLayer) {
+		expect := expect.New(t)
+
+		s := syntax.New()
+		err := s.Parse(src)
+		expect(err).To(BeNil())
+
+		return expect, s.Layers()
+	})
+
+	matchers := []matchPosition{
+		{src: src, match: "package"},
+		{src: src, match: "import"},
+		{src: src, match: "var"},
+		{src: src, match: "map"},
+		{src: src, match: "const"},
+		{src: src, match: "type"},
+		{src: src, match: "struct"},
+		{src: src, idx: 1, match: "type"},
+		{src: src, match: "interface"},
+		{src: src, match: "func"},
+		{src: src, match: "chan"},
+		{src: src, idx: 1, match: "chan"},
+		{src: src, idx: 1, match: "struct"},
+		{src: src, match: "go"},
+		{src: src, idx: 1, match: "func"},
+		{src: src, idx: 1, match: "var"},
+		{src: src, match: "chan<-"},
+		{src: src, idx: 2, match: "struct"},
+		{src: src, match: "defer"},
+		{src: src, match: "for"},
+		{src: src, match: "range"},
+		{src: src, idx: 2, match: "var"},
+		{src: src, match: "<-chan"},
+		{src: src, idx: 3, match: "struct"},
+		{src: src, match: "goto"},
+		{src: src, idx: 1, match: "for"},
+		{src: src, match: "if"},
+		{src: src, match: "break"},
+		{src: src, match: "else"},
+		{src: src, idx: 1, match: "if"},
+		{src: src, match: "continue"},
+		{src: src, idx: 1, match: "else"},
+		{src: src, match: "switch"},
+		{src: src, match: "case"},
+		{src: src, match: "fallthrough"},
+		{src: src, match: "default"},
+		{src: src, match: "return"},
+		{src: src, match: "select"},
+		{src: src, idx: 1, match: "case"},
+		{src: src, idx: 1, match: "default"},
 	}
-	`
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil().Else.FailNow()
 
-	layers := s.Layers()
-
-	keywords := findLayer(theme.Keyword, layers)
-
-	expect(keywords.Spans[0]).To.Pass(position{src: src, match: "package"})
-	expect(keywords.Spans[1]).To.Pass(position{src: src, match: "import"})
-	expect(keywords.Spans[2]).To.Pass(position{src: src, match: "var"})
-	expect(keywords.Spans[3]).To.Pass(position{src: src, match: "map"})
-	expect(keywords.Spans[4]).To.Pass(position{src: src, match: "const"})
-	expect(keywords.Spans[5]).To.Pass(position{src: src, match: "type"})
-	expect(keywords.Spans[6]).To.Pass(position{src: src, match: "struct"})
-	expect(keywords.Spans[7]).To.Pass(position{src: src, idx: 1, match: "type"})
-	expect(keywords.Spans[8]).To.Pass(position{src: src, match: "interface"})
-	expect(keywords.Spans[9]).To.Pass(position{src: src, match: "func"})
-	expect(keywords.Spans[10]).To.Pass(position{src: src, match: "chan"})
-	expect(keywords.Spans[11]).To.Pass(position{src: src, idx: 1, match: "chan"})
-	expect(keywords.Spans[12]).To.Pass(position{src: src, idx: 1, match: "struct"})
-	expect(keywords.Spans[13]).To.Pass(position{src: src, match: "go"})
-	expect(keywords.Spans[14]).To.Pass(position{src: src, idx: 1, match: "func"})
-	expect(keywords.Spans[15]).To.Pass(position{src: src, idx: 1, match: "var"})
-	expect(keywords.Spans[16]).To.Pass(position{src: src, match: "chan<-"})
-	expect(keywords.Spans[17]).To.Pass(position{src: src, idx: 2, match: "struct"})
-	expect(keywords.Spans[18]).To.Pass(position{src: src, match: "defer"})
-	expect(keywords.Spans[19]).To.Pass(position{src: src, match: "for"})
-	expect(keywords.Spans[20]).To.Pass(position{src: src, match: "range"})
-	expect(keywords.Spans[21]).To.Pass(position{src: src, idx: 2, match: "var"})
-	expect(keywords.Spans[22]).To.Pass(position{src: src, match: "<-chan"})
-	expect(keywords.Spans[23]).To.Pass(position{src: src, idx: 3, match: "struct"})
-	expect(keywords.Spans[24]).To.Pass(position{src: src, match: "goto"})
-	expect(keywords.Spans[25]).To.Pass(position{src: src, idx: 1, match: "for"})
-	expect(keywords.Spans[26]).To.Pass(position{src: src, match: "if"})
-	expect(keywords.Spans[27]).To.Pass(position{src: src, match: "break"})
-	expect(keywords.Spans[28]).To.Pass(position{src: src, match: "else"})
-	expect(keywords.Spans[29]).To.Pass(position{src: src, idx: 1, match: "if"})
-	expect(keywords.Spans[30]).To.Pass(position{src: src, match: "continue"})
-	expect(keywords.Spans[31]).To.Pass(position{src: src, idx: 1, match: "else"})
-	expect(keywords.Spans[32]).To.Pass(position{src: src, match: "switch"})
-	expect(keywords.Spans[33]).To.Pass(position{src: src, match: "case"})
-	expect(keywords.Spans[34]).To.Pass(position{src: src, match: "fallthrough"})
-	expect(keywords.Spans[35]).To.Pass(position{src: src, match: "default"})
-	expect(keywords.Spans[36]).To.Pass(position{src: src, match: "return"})
-	expect(keywords.Spans[37]).To.Pass(position{src: src, match: "select"})
-	expect(keywords.Spans[38]).To.Pass(position{src: src, idx: 1, match: "case"})
-	expect(keywords.Spans[39]).To.Pass(position{src: src, idx: 1, match: "default"})
+	for idx, match := range matchers {
+		name := fmt.Sprintf("%d%s %s", match.idx+1, numSuffix(match.idx+1), match.match)
+		o.Spec(name, func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			keywords := findLayer(theme.Keyword, layers)
+			expect(keywords.Spans[idx]).To(match)
+		})
+	}
 }

--- a/syntax/keywords_test.go
+++ b/syntax/keywords_test.go
@@ -68,7 +68,7 @@ FOO:
 
 	layers := s.Layers()
 
-	keywords := layers[theme.Keyword]
+	keywords := findLayer(theme.Keyword, layers)
 
 	expect(keywords.Spans[0]).To.Pass(position{src: src, match: "package"})
 	expect(keywords.Spans[1]).To.Pass(position{src: src, match: "import"})

--- a/syntax/layers.go
+++ b/syntax/layers.go
@@ -73,8 +73,12 @@ func (s *Syntax) Parse(source string) error {
 // gxui.CodeSyntaxLayer will have its foreground and background
 // constructs set, and all positions that should be highlighted that
 // construct will be stored.
-func (s *Syntax) Layers() map[theme.LanguageConstruct]*input.SyntaxLayer {
-	return s.layers
+func (s *Syntax) Layers() []input.SyntaxLayer {
+	l := make([]input.SyntaxLayer, 0, len(s.layers))
+	for _, layer := range s.layers {
+		l = append(l, *layer)
+	}
+	return l
 }
 
 func (s *Syntax) rainbowScope(openStart token.Pos, openLen int, closeStart token.Pos, closeLen int) (unscope func()) {

--- a/syntax/parens_test.go
+++ b/syntax/parens_test.go
@@ -34,7 +34,7 @@ func FuncBody(t *testing.T) {
 
 	layers := s.Layers()
 
-	firstParens := layers[theme.ScopePair]
+	firstParens := findLayer(theme.ScopePair, layers)
 	expect(firstParens.Spans).To.Have.Len(6).Else.FailNow()
 
 	expect(firstParens.Spans[0]).To.Pass(position{src: src, match: "("})
@@ -44,7 +44,7 @@ func FuncBody(t *testing.T) {
 	expect(firstParens.Spans[4]).To.Pass(position{src: src, match: "{"})
 	expect(firstParens.Spans[5]).To.Pass(position{src: src, match: "}"})
 
-	secondParens := layers[theme.ScopePair+1]
+	secondParens := findLayer(theme.ScopePair+1, layers)
 	expect(secondParens.Spans).To.Have.Len(2).Else.FailNow()
 	expect(secondParens.Spans[0]).To.Pass(position{src: src, match: "(", idx: 2})
 	expect(secondParens.Spans[1]).To.Pass(position{src: src, match: ")", idx: 2})
@@ -68,7 +68,7 @@ func Array(t *testing.T) {
 	layers := s.Layers()
 
 	// Skip the function ScopePair
-	arrParens := layers[theme.ScopePair+1]
+	arrParens := findLayer(theme.ScopePair+1, layers)
 	expect(arrParens.Spans).To.Have.Len(6).Else.FailNow()
 	expect(arrParens.Spans[0]).To.Pass(position{src: src, match: "["})
 	expect(arrParens.Spans[1]).To.Pass(position{src: src, match: "]"})
@@ -77,7 +77,7 @@ func Array(t *testing.T) {
 	expect(arrParens.Spans[4]).To.Pass(position{src: src, match: "{", idx: 1})
 	expect(arrParens.Spans[5]).To.Pass(position{src: src, match: "}"})
 
-	typs := layers[theme.Type]
+	typs := findLayer(theme.Type, layers)
 	expect(typs.Spans).To.Have.Len(2).Else.FailNow()
 	expect(typs.Spans[0]).To.Pass(position{src: src, match: "string"})
 	expect(typs.Spans[1]).To.Pass(position{src: src, match: "string", idx: 1})
@@ -104,7 +104,7 @@ func Slice(t *testing.T) {
 	layers := s.Layers()
 
 	// Skip the function ScopePair
-	arrParens := layers[theme.ScopePair+1]
+	arrParens := findLayer(theme.ScopePair+1, layers)
 	expect(arrParens.Spans).To.Have.Len(12).Else.FailNow()
 	// 0 and 1 are the [3]string, for an array type.
 	expect(arrParens.Spans[2]).To.Pass(position{src: src, match: "[", idx: 1})

--- a/syntax/parens_test.go
+++ b/syntax/parens_test.go
@@ -7,114 +7,133 @@ package syntax_test
 import (
 	"testing"
 
-	"github.com/a8m/expect"
+	"github.com/apoydence/onpar"
+	"github.com/apoydence/onpar/expect"
+	. "github.com/apoydence/onpar/matchers"
+	"github.com/nelsam/vidar/commander/input"
 	"github.com/nelsam/vidar/syntax"
 	"github.com/nelsam/vidar/theme"
 )
 
 func TestParens(t *testing.T) {
-	t.Run("FunctionBody", FuncBody)
-	t.Run("Array", Array)
-	t.Run("Slice", Slice)
-}
+	o := onpar.New()
+	defer o.Run(t)
 
-func FuncBody(t *testing.T) {
-	expect := expect.New(t)
+	o.BeforeEach(func(t *testing.T) expect.Expectation {
+		return expect.New(t)
+	})
 
-	src := `
-	package foo
-
-	func (*Foo) Foo(baz Baz) {
-		baz.Bar()
-	}
-	`
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil().Else.FailNow()
-
-	layers := s.Layers()
-
-	firstParens := findLayer(theme.ScopePair, layers)
-	expect(firstParens.Spans).To.Have.Len(6).Else.FailNow()
-
-	expect(firstParens.Spans[0]).To.Pass(position{src: src, match: "("})
-	expect(firstParens.Spans[1]).To.Pass(position{src: src, match: ")"})
-	expect(firstParens.Spans[2]).To.Pass(position{src: src, match: "(", idx: 1})
-	expect(firstParens.Spans[3]).To.Pass(position{src: src, match: ")", idx: 1})
-	expect(firstParens.Spans[4]).To.Pass(position{src: src, match: "{"})
-	expect(firstParens.Spans[5]).To.Pass(position{src: src, match: "}"})
-
-	secondParens := findLayer(theme.ScopePair+1, layers)
-	expect(secondParens.Spans).To.Have.Len(2).Else.FailNow()
-	expect(secondParens.Spans[0]).To.Pass(position{src: src, match: "(", idx: 2})
-	expect(secondParens.Spans[1]).To.Pass(position{src: src, match: ")", idx: 2})
-}
-
-func Array(t *testing.T) {
-	expect := expect.New(t)
-
-	src := `
-	package foo
+	o.Group("FunctionBody", func() {
+		// Note: there needs to be a newline after the closing brace for it to
+		// parse correctly.
+		const src = `
+		package foo
 	
-	func main() {
-		var v [3]string
-		v := [...]string{"foo"}
-	}
-	`
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil().Else.FailNow()
+		func (*Foo) Foo(baz Baz) {
+			baz.Bar()
+		}
+		`
 
-	layers := s.Layers()
+		o.BeforeEach(func(expect expect.Expectation) (expect.Expectation, []input.SyntaxLayer) {
+			s := syntax.New()
+			err := s.Parse(src)
+			expect(err).To(BeNil())
 
-	// Skip the function ScopePair
-	arrParens := findLayer(theme.ScopePair+1, layers)
-	expect(arrParens.Spans).To.Have.Len(6).Else.FailNow()
-	expect(arrParens.Spans[0]).To.Pass(position{src: src, match: "["})
-	expect(arrParens.Spans[1]).To.Pass(position{src: src, match: "]"})
-	expect(arrParens.Spans[2]).To.Pass(position{src: src, match: "[", idx: 1})
-	expect(arrParens.Spans[3]).To.Pass(position{src: src, match: "]", idx: 1})
-	expect(arrParens.Spans[4]).To.Pass(position{src: src, match: "{", idx: 1})
-	expect(arrParens.Spans[5]).To.Pass(position{src: src, match: "}"})
+			return expect, s.Layers()
+		})
 
-	typs := findLayer(theme.Type, layers)
-	expect(typs.Spans).To.Have.Len(2).Else.FailNow()
-	expect(typs.Spans[0]).To.Pass(position{src: src, match: "string"})
-	expect(typs.Spans[1]).To.Pass(position{src: src, match: "string", idx: 1})
-}
+		o.Spec("it highlights the outer-most scope pairs with one color", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			outerScope := findLayer(theme.ScopePair, layers)
+			expect(outerScope.Spans).To(HaveLen(6))
 
-func Slice(t *testing.T) {
-	expect := expect.New(t)
+			expect(outerScope.Spans[0]).To(matchPosition{src: src, match: "("})
+			expect(outerScope.Spans[1]).To(matchPosition{src: src, match: ")"})
+			expect(outerScope.Spans[2]).To(matchPosition{src: src, match: "(", idx: 1})
+			expect(outerScope.Spans[3]).To(matchPosition{src: src, match: ")", idx: 1})
+			expect(outerScope.Spans[4]).To(matchPosition{src: src, match: "{"})
+			expect(outerScope.Spans[5]).To(matchPosition{src: src, match: "}"})
+		})
 
-	src := `
-	package foo
-	
-	func main() {
-		var v [3]string
-		u := v[:]
-		x := []string{"foo"}
-		y := x[1:]
-		z := x[:1]
-	}
-	`
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil().Else.FailNow()
+		o.Spec("it highlights the nested scope pairs with a different color", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			secondParens := findLayer(theme.ScopePair+1, layers)
+			expect(secondParens.Spans).To(HaveLen(2))
+			expect(secondParens.Spans[0]).To(matchPosition{src: src, match: "(", idx: 2})
+			expect(secondParens.Spans[1]).To(matchPosition{src: src, match: ")", idx: 2})
+		})
+	})
 
-	layers := s.Layers()
+	o.Group("Array", func() {
+		const src = `
+		package foo
+		
+		func main() {
+			var v [3]string
+			v := [...]string{"foo"}
+		}`
 
-	// Skip the function ScopePair
-	arrParens := findLayer(theme.ScopePair+1, layers)
-	expect(arrParens.Spans).To.Have.Len(12).Else.FailNow()
-	// 0 and 1 are the [3]string, for an array type.
-	expect(arrParens.Spans[2]).To.Pass(position{src: src, match: "[", idx: 1})
-	expect(arrParens.Spans[3]).To.Pass(position{src: src, match: "]", idx: 1})
-	expect(arrParens.Spans[4]).To.Pass(position{src: src, match: "[", idx: 2})
-	expect(arrParens.Spans[5]).To.Pass(position{src: src, match: "]", idx: 2})
-	expect(arrParens.Spans[6]).To.Pass(position{src: src, match: "{", idx: 1})
-	expect(arrParens.Spans[7]).To.Pass(position{src: src, match: "}"})
-	expect(arrParens.Spans[8]).To.Pass(position{src: src, match: "[", idx: 3})
-	expect(arrParens.Spans[9]).To.Pass(position{src: src, match: "]", idx: 3})
-	expect(arrParens.Spans[10]).To.Pass(position{src: src, match: "[", idx: 4})
-	expect(arrParens.Spans[11]).To.Pass(position{src: src, match: "]", idx: 4})
+		o.BeforeEach(func(expect expect.Expectation) (expect.Expectation, []input.SyntaxLayer) {
+			s := syntax.New()
+			err := s.Parse(src)
+			expect(err).To(BeNil())
+
+			return expect, s.Layers()
+		})
+
+		o.Spec("it highlights array brackets and braces in a nested scope", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			arrParens := findLayer(theme.ScopePair+1, layers)
+			expect(arrParens.Spans).To(HaveLen(6))
+			expect(arrParens.Spans[0]).To(matchPosition{src: src, match: "["})
+			expect(arrParens.Spans[1]).To(matchPosition{src: src, match: "]"})
+			expect(arrParens.Spans[2]).To(matchPosition{src: src, match: "[", idx: 1})
+			expect(arrParens.Spans[3]).To(matchPosition{src: src, match: "]", idx: 1})
+			expect(arrParens.Spans[4]).To(matchPosition{src: src, match: "{", idx: 1})
+			expect(arrParens.Spans[5]).To(matchPosition{src: src, match: "}"})
+		})
+
+		o.Spec("it highlights array types", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			typs := findLayer(theme.Type, layers)
+			expect(typs.Spans).To(HaveLen(2))
+			expect(typs.Spans[0]).To(matchPosition{src: src, match: "string"})
+			expect(typs.Spans[1]).To(matchPosition{src: src, match: "string", idx: 1})
+		})
+	})
+
+	o.Group("Slice", func() {
+		const src = `
+		package foo
+		
+		func main() {
+			var v []string
+			u := v[:]
+			x := []string{"foo"}
+			y := x[1:]
+			z := x[:1]
+		}`
+
+		o.BeforeEach(func(expect expect.Expectation) (expect.Expectation, []input.SyntaxLayer) {
+			s := syntax.New()
+			err := s.Parse(src)
+			expect(err).To(BeNil())
+
+			return expect, s.Layers()
+		})
+
+		o.Spec("it highlights brackets and braces for slices within a nested scope", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			arrParens := findLayer(theme.ScopePair+1, layers)
+			expect(arrParens.Spans).To(HaveLen(12))
+
+			expect(arrParens.Spans[0]).To(matchPosition{src: src, match: "["})
+			expect(arrParens.Spans[1]).To(matchPosition{src: src, match: "]"})
+			expect(arrParens.Spans[2]).To(matchPosition{src: src, match: "[", idx: 1})
+			expect(arrParens.Spans[3]).To(matchPosition{src: src, match: "]", idx: 1})
+			expect(arrParens.Spans[4]).To(matchPosition{src: src, match: "[", idx: 2})
+			expect(arrParens.Spans[5]).To(matchPosition{src: src, match: "]", idx: 2})
+			expect(arrParens.Spans[6]).To(matchPosition{src: src, match: "{", idx: 1})
+			expect(arrParens.Spans[7]).To(matchPosition{src: src, match: "}"})
+			expect(arrParens.Spans[8]).To(matchPosition{src: src, match: "[", idx: 3})
+			expect(arrParens.Spans[9]).To(matchPosition{src: src, match: "]", idx: 3})
+			expect(arrParens.Spans[10]).To(matchPosition{src: src, match: "[", idx: 4})
+			expect(arrParens.Spans[11]).To(matchPosition{src: src, match: "]", idx: 4})
+		})
+	})
 }

--- a/syntax/stmt_test.go
+++ b/syntax/stmt_test.go
@@ -7,82 +7,105 @@ package syntax_test
 import (
 	"testing"
 
-	"github.com/a8m/expect"
+	"github.com/nelsam/vidar/commander/input"
 	"github.com/nelsam/vidar/syntax"
 	"github.com/nelsam/vidar/theme"
+
+	"github.com/apoydence/onpar"
+	"github.com/apoydence/onpar/expect"
+	. "github.com/apoydence/onpar/matchers"
 )
 
 func TestStmt(t *testing.T) {
-	t.Run("Assign", AssignStmt)
-	t.Run("CommClause", CommClause)
-}
+	o := onpar.New()
+	defer o.Run(t)
 
-func AssignStmt(t *testing.T) {
-	expect := expect.New(t)
+	o.BeforeEach(func(t *testing.T) expect.Expectation {
+		return expect.New(t)
+	})
 
-	src := `
-package foo
-	
-func main() {
-	x := 0.1
-	y = "foo"
-}`
+	o.Group("Assign", func() {
+		const src = `
+		package foo
 
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil()
+		func main() {
+			x := 0.1
+			y = "foo"
+		}`
 
-	layers := s.Layers()
-	expect(layers).To.Have.Len(6)
+		o.BeforeEach(func(expect expect.Expectation) (expect.Expectation, []input.SyntaxLayer) {
+			s := syntax.New()
+			err := s.Parse(src)
+			expect(err).To(BeNil())
 
-	nums := findLayer(theme.Num, layers)
-	expect(nums.Spans).To.Have.Len(1)
-	expect(nums.Spans[0]).To.Pass(position{src: src, match: "0.1"})
+			layers := s.Layers()
+			expect(layers).To(HaveLen(6))
 
-	strings := findLayer(theme.String, layers)
-	expect(strings.Spans).To.Have.Len(1)
-	expect(strings.Spans[0]).To.Pass(position{src: src, match: `"foo"`})
-}
+			return expect, layers
+		})
 
-func CommClause(t *testing.T) {
-	expect := expect.New(t)
+		o.Spec("it has a number layer for 0.1", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			nums := findLayer(theme.Num, layers)
+			expect(nums.Spans).To(HaveLen(1))
+			expect(nums.Spans[0]).To(matchPosition{src: src, match: "0.1"})
+		})
 
-	src := `
-package foo
+		o.Spec(`it has a string layer for "foo"`, func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			strings := findLayer(theme.String, layers)
+			expect(strings.Spans).To(HaveLen(1))
+			expect(strings.Spans[0]).To(matchPosition{src: src, match: `"foo"`})
+		})
+	})
 
-func main() {
-	switch {
-	case foo == "bar":
-		x = 1
-	case y == false:
-	default:
-		println("bacon")
-	}
-}`
+	o.Group("CommClause", func() {
+		const src = `
+		package foo
+		
+		func main() {
+			switch {
+			case foo == "bar":
+				x = 1
+			case y == false:
+			default:
+				println("bacon")
+			}
+		}`
 
-	s := syntax.New()
-	err := s.Parse(src)
-	expect(err).To.Be.Nil()
+		o.BeforeEach(func(expect expect.Expectation) (expect.Expectation, []input.SyntaxLayer) {
+			s := syntax.New()
+			err := s.Parse(src)
+			expect(err).To(BeNil())
 
-	layers := s.Layers()
-	expect(layers).To.Have.Len(9)
+			layers := s.Layers()
+			expect(layers).To(HaveLen(9))
+			return expect, layers
+		})
 
-	keywords := findLayer(theme.Keyword, layers)
-	expect(keywords.Spans).To.Have.Len(6)
-	expect(keywords.Spans[3]).To.Pass(position{src: src, match: "case"})
-	expect(keywords.Spans[4]).To.Pass(position{src: src, match: "case", idx: 1})
-	expect(keywords.Spans[5]).To.Pass(position{src: src, match: "default"})
+		o.Spec("it has keyword spans for the cases", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			keywords := findLayer(theme.Keyword, layers)
+			expect(keywords.Spans).To(HaveLen(6))
+			expect(keywords.Spans[3]).To(matchPosition{src: src, match: "case"})
+			expect(keywords.Spans[4]).To(matchPosition{src: src, match: "case", idx: 1})
+			expect(keywords.Spans[5]).To(matchPosition{src: src, match: "default"})
+		})
 
-	strings := findLayer(theme.String, layers)
-	expect(strings.Spans).To.Have.Len(2)
-	expect(strings.Spans[0]).To.Pass(position{src: src, match: `"bar"`})
-	expect(strings.Spans[1]).To.Pass(position{src: src, match: `"bacon"`})
+		o.Spec("it has string spans for the string cases", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			strings := findLayer(theme.String, layers)
+			expect(strings.Spans).To(HaveLen(2))
+			expect(strings.Spans[0]).To(matchPosition{src: src, match: `"bar"`})
+			expect(strings.Spans[1]).To(matchPosition{src: src, match: `"bacon"`})
+		})
 
-	nums := findLayer(theme.Num, layers)
-	expect(nums.Spans).To.Have.Len(1)
-	expect(nums.Spans[0]).To.Pass(position{src: src, match: "1"})
+		o.Spec("it has num spans for the numeric cases", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			nums := findLayer(theme.Num, layers)
+			expect(nums.Spans).To(HaveLen(1))
+			expect(nums.Spans[0]).To(matchPosition{src: src, match: "1"})
+		})
 
-	builtins := findLayer(theme.Builtin, layers)
-	expect(builtins.Spans).To.Have.Len(1)
-	expect(builtins.Spans[0]).To.Pass(position{src: src, match: "println"})
+		o.Spec("it has builtin spans for the builtin functions", func(expect expect.Expectation, layers []input.SyntaxLayer) {
+			builtins := findLayer(theme.Builtin, layers)
+			expect(builtins.Spans).To(HaveLen(1))
+			expect(builtins.Spans[0]).To(matchPosition{src: src, match: "println"})
+		})
+	})
 }

--- a/syntax/stmt_test.go
+++ b/syntax/stmt_test.go
@@ -35,11 +35,11 @@ func main() {
 	layers := s.Layers()
 	expect(layers).To.Have.Len(6)
 
-	nums := layers[theme.Num]
+	nums := findLayer(theme.Num, layers)
 	expect(nums.Spans).To.Have.Len(1)
 	expect(nums.Spans[0]).To.Pass(position{src: src, match: "0.1"})
 
-	strings := layers[theme.String]
+	strings := findLayer(theme.String, layers)
 	expect(strings.Spans).To.Have.Len(1)
 	expect(strings.Spans[0]).To.Pass(position{src: src, match: `"foo"`})
 }
@@ -67,22 +67,22 @@ func main() {
 	layers := s.Layers()
 	expect(layers).To.Have.Len(9)
 
-	keywords := layers[theme.Keyword]
+	keywords := findLayer(theme.Keyword, layers)
 	expect(keywords.Spans).To.Have.Len(6)
 	expect(keywords.Spans[3]).To.Pass(position{src: src, match: "case"})
 	expect(keywords.Spans[4]).To.Pass(position{src: src, match: "case", idx: 1})
 	expect(keywords.Spans[5]).To.Pass(position{src: src, match: "default"})
 
-	strings := layers[theme.String]
+	strings := findLayer(theme.String, layers)
 	expect(strings.Spans).To.Have.Len(2)
 	expect(strings.Spans[0]).To.Pass(position{src: src, match: `"bar"`})
 	expect(strings.Spans[1]).To.Pass(position{src: src, match: `"bacon"`})
 
-	nums := layers[theme.Num]
+	nums := findLayer(theme.Num, layers)
 	expect(nums.Spans).To.Have.Len(1)
 	expect(nums.Spans[0]).To.Pass(position{src: src, match: "1"})
 
-	builtins := layers[theme.Builtin]
+	builtins := findLayer(theme.Builtin, layers)
 	expect(builtins.Spans).To.Have.Len(1)
 	expect(builtins.Spans[0]).To.Pass(position{src: src, match: "println"})
 }


### PR DESCRIPTION
As per #147, we were seeing occasional concurrent map writes and reads.  This is the quick, obvious
fix for the issue, although we should take another look after the fix is confirmed to see if we
really need the _same_ syntax parser in both goroutines.  On the one hand, we probably don't want
to assume that all of the code will be re-parsed from scratch; on the other hand, we're not passing
along any information about which spans could have changed.

Resolves #147

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
