### PR TITLE
Extending input.Editor by method Runes and fixing bug in toggle comments for unicode text.  

### DIFF
--- a/commander/input/editor.go
+++ b/commander/input/editor.go
@@ -17,6 +17,7 @@ package input
 type Editor interface {
 	Filepath() string
 	Text() string
+	Runes() []rune
 	SetText(string)
 	SyntaxLayers() []SyntaxLayer
 	SetSyntaxLayers([]SyntaxLayer)

--- a/plugin/comments/toggle.go
+++ b/plugin/comments/toggle.go
@@ -77,13 +77,13 @@ func (t *Toggle) Exec() error {
 	var edits []input.Edit
 	for i := len(selections) - 1; i >= 0; i-- {
 		begin, end := selections[i].Start(), selections[i].End()
-		str := t.editor.Text()[begin:end]
+		runes := t.editor.Runes()[begin:end]
+		str := string(runes)
 		re, replace := regexpReplace(str)
 		newstr := re.ReplaceAllString(str, replace)
-
 		edits = append(edits, input.Edit{
 			At:  int(begin),
-			Old: []rune(str),
+			Old: runes,
 			New: []rune(newstr),
 		})
 	}


### PR DESCRIPTION
I think that method Runes can be useful for another case too, so I added it to input.Editor instead usual converting into runes. 

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [x] Windows
* [ ] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
