### PR TITLE
Change margin for linenumber

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -339,6 +339,7 @@ func (e *CodeEditor) KeyStroke(event gxui.KeyStrokeEvent) (consume bool) {
 func (e *CodeEditor) CreateLine(theme gxui.Theme, index int) (mixins.TextBoxLine, gxui.Control) {
 	lineNumber := theme.CreateLabel()
 	lineNumber.SetText(fmt.Sprintf("%4d", index+1))
+	lineNumber.SetMargin(math.Spacing{L: 0, T: 0, R: 3, B: 0})
 
 	line := &mixins.CodeEditorLine{}
 	line.Init(line, theme, &e.CodeEditor, index)


### PR DESCRIPTION
Using non-defaults fonts doesn't show whole label for some reason. If change margin for label from 3([default label value](https://github.com/nelsam/gxui/blob/master/themes/basic/label.go#L16)) to 0 this behaviour change. Default font also keeps look good.   

Before :
![before](https://user-images.githubusercontent.com/17313967/50051630-f6a27780-011e-11e9-8e93-0bec7ebd8a13.jpg)
After : 
![after](https://user-images.githubusercontent.com/17313967/50051631-fd30ef00-011e-11e9-9a83-f8b7f1b9be3e.jpg)

But I don't see any reason keep use this overloading and would prefer apply this change to base class in [mixins](https://github.com/nelsam/gxui/blob/master/mixins/code_editor.go#L241) since there aren't any significant [differences](https://www.diffchecker.com/i2VCi5st). 

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [ ] Bug Fix
* [ ] New Feature
* [x] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [x] Windows
* [ ] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
