### PR TITLE
Update windows paths

### DIFF
--- a/setting/paths_windows.go
+++ b/setting/paths_windows.go
@@ -17,5 +17,6 @@ var (
 	fontPaths = []string{
 		filepath.Join(xdg.DataHome(), "FONTS"),
 		filepath.Join(os.Getenv("SYSTEMDRIVE"), "WINDOWS", "FONTS"),
+		filepath.Join(os.Getenv("SYSTEMDRIVE")+"//", "WINDOWS", "FONTS"),
 	}
 )


### PR DESCRIPTION
For some reason filepath.Join doesn't work as expected with os.Getenv("SYSTEMDRIVE") at least for Win10. I'm not sure why I didn't found the issue when tested before. As an alternative can use usual path.Join instead of path/filepath.  

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [x] Windows
* [ ] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
