### PR TITLE
navigator/project_tree: force a switch _before_ doing redraw/relayout

### DIFF
--- a/fsw/poller.go
+++ b/fsw/poller.go
@@ -159,6 +159,18 @@ func (p *poller) Remove(name string) error {
 	return nil
 }
 
+func (p *poller) RemoveAll() error {
+	if atomic.LoadUint32(&p.closed) == 1 {
+		return errors.New("RemoveAll called on closed poller")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for n := range p.last {
+		delete(p.last, n)
+	}
+	return nil
+}
+
 func (p *poller) Close() error {
 	p.ticker.Stop()
 	atomic.StoreUint32(&p.closed, 1)

--- a/fsw/watcher.go
+++ b/fsw/watcher.go
@@ -27,6 +27,7 @@ type Event struct {
 type Watcher interface {
 	Add(name string) error
 	Remove(name string) error
+	RemoveAll() error
 	Close() error
 	Next() (Event, error)
 }

--- a/navigator/directory.go
+++ b/navigator/directory.go
@@ -183,11 +183,16 @@ func (d *dirTree) Unload(w Watcher) error {
 			return err
 		}
 	}
+	if w == nil {
+		return nil
+	}
 	return w.Remove(d.path)
 }
 
 func (d *dirTree) Load(w Watcher) error {
-	w.Add(d.path)
+	if w != nil {
+		w.Add(d.path)
+	}
 	finfos, err := ioutil.ReadDir(d.path)
 	if err != nil {
 		return err

--- a/navigator/project_tree.go
+++ b/navigator/project_tree.go
@@ -205,18 +205,17 @@ func (p *ProjectTree) update(path string) {
 }
 
 func (p *ProjectTree) SetProject(project setting.Project) {
-	p.SetRoot(project.Path)
-
+	// Ensure that the project tree is the current pane before
+	// the UI goroutine process switches.
 	p.driver.Call(func() {
 		if p.layout.Attached() {
 			return
 		}
-		// For now, for some visual indication that the project has changed, we
-		// force open the project pane here.
 		p.button.Click(gxui.MouseEvent{
 			Button: gxui.MouseButtonLeft,
 		})
 	})
+	p.SetRoot(project.Path)
 }
 
 func (p *ProjectTree) Open(path string, pos token.Position) {

--- a/navigator/project_tree.go
+++ b/navigator/project_tree.go
@@ -82,10 +82,22 @@ func NewProjectTree(cmdr Commander, driver gxui.Driver, window gxui.Window, them
 		button:     createIconButton(driver, theme, "folder.png"),
 		layout:     newSplitterLayout(window, theme),
 	}
+	tree.initWatcher()
 	tree.layout.SetOrientation(gxui.Vertical)
 	tree.SetProject(setting.DefaultProject)
 
 	return tree
+}
+
+func (p *ProjectTree) initWatcher() {
+	w, err := fsw.New()
+	if err != nil {
+		// TODO: report to the UI
+		log.Printf("WARNING: could not watch project tree: %s", err)
+		return
+	}
+	p.watcher = w
+	go p.watch()
 }
 
 func (p *ProjectTree) SetTOC(toc *TOC) {
@@ -110,14 +122,10 @@ func (p *ProjectTree) SetRoot(path string) {
 	p.tocCtl = nil
 
 	if p.watcher != nil {
-		p.watcher.Close()
+		if err := p.watcher.RemoveAll(); err != nil {
+			log.Printf("WARNING: failed to remove current watches from watcher: %s", err)
+		}
 	}
-	watcher, err := fsw.New()
-	if err != nil {
-		log.Printf("Error creating project tree watcher: %s", err)
-	}
-	p.watcher = watcher
-	p.startWatch(path)
 
 	p.driver.Call(func() {
 		p.dirs = newDirectory(p, path, p.watcher)
@@ -135,15 +143,6 @@ func (p *ProjectTree) SetRoot(path string) {
 		p.layout.Relayout()
 		p.layout.Redraw()
 	})
-}
-
-func (p *ProjectTree) startWatch(root string) {
-	if p.watcher == nil {
-		return
-	}
-
-	go p.watch()
-
 }
 
 // watch waits for events from p.watcher.  For each event, the tree will
@@ -206,7 +205,7 @@ func (p *ProjectTree) update(path string) {
 
 func (p *ProjectTree) SetProject(project setting.Project) {
 	// Ensure that the project tree is the current pane before
-	// the UI goroutine process switches.
+	// the UI goroutine does our relayout/redraw logic.
 	p.driver.Call(func() {
 		if p.layout.Attached() {
 			return


### PR DESCRIPTION
When the project was changed via the UI, the open navigator pane would change _after_ all of the redraw/relayout logic
happened.  This caused the project tree to be unresponsive and often display the incorrect project.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests

The `navigator` package is probably the oldest, crustiest part of vidar right now, and it needs a major rewrite to be testable.  I don't even want to try to test it right now.