### PR TITLE
Don't expand project tree at start

### DIFF
--- a/navigator/project_tree.go
+++ b/navigator/project_tree.go
@@ -84,7 +84,7 @@ func NewProjectTree(cmdr Commander, driver gxui.Driver, window gxui.Window, them
 	}
 	tree.initWatcher()
 	tree.layout.SetOrientation(gxui.Vertical)
-	tree.SetProject(setting.DefaultProject)
+	tree.SetRoot(setting.DefaultProject.Path)
 
 	return tree
 }


### PR DESCRIPTION
Function SetProject/1 [produce a click](https://github.com/nelsam/vidar/blob/master/navigator/project_tree.go#L213) and call SetRoot/1. So it can be safely changing to SetRoot/1 only at start application. 

Fixes: #146 

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [ ] Bug Fix
* [ ] New Feature
* [x] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [x] Windows
* [ ] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
