### PR TITLE
gocode: fix off-by-one error (<= instead of <)

### DIFF
--- a/plugin/gocode/list.go
+++ b/plugin/gocode/list.go
@@ -38,7 +38,7 @@ type Applier interface {
 type suggestionList struct {
 	mixins.List
 	driver  gxui.Driver
-	adapter *suggestions.Adapter
+	adapter *suggestion.Adapter
 	font    gxui.Font
 	project setting.Project
 	editor  Editor
@@ -50,7 +50,7 @@ type suggestionList struct {
 func newSuggestionList(driver gxui.Driver, theme *basic.Theme, proj setting.Project, editor Editor, ctrl TextController, applier Applier, gocode *GoCode) *suggestionList {
 	s := &suggestionList{
 		driver:  driver,
-		adapter: &suggestions.Adapter{},
+		adapter: &suggestion.Adapter{},
 		font:    theme.DefaultMonospaceFont(),
 		project: proj,
 		editor:  editor,
@@ -102,8 +102,8 @@ func (s *suggestionList) show(ctx context.Context, pos int) int {
 		if ctxCancelled(ctx) {
 			return 0
 		}
-		suggestions := s.parseSuggestions(runes, start)
-		s.adapter.Set(start, suggestions...)
+		suggestion := s.parseSuggestions(runes, start)
+		s.adapter.Set(start, suggestion...)
 	}
 	if ctxCancelled(ctx) {
 		return 0
@@ -124,17 +124,17 @@ func (s *suggestionList) show(ctx context.Context, pos int) int {
 	return s.adapter.Len()
 }
 
-func (s *suggestionList) parseSuggestions(runes []rune, start int) []suggestions.Suggestion {
-	suggestions, err := suggestions.For(s.project.Environ(), s.editor.Filepath(), string(runes), start)
+func (s *suggestionList) parseSuggestions(runes []rune, start int) []suggestion.Suggestion {
+	suggestion, err := suggestion.For(s.project.Environ(), s.editor.Filepath(), string(runes), start)
 	if err != nil {
-		log.Printf("Failed to load suggestions: %s", err)
+		log.Printf("Failed to load suggestion: %s", err)
 		return nil
 	}
-	return suggestions
+	return suggestion
 }
 
 func (s *suggestionList) apply() {
-	suggestion := s.Selected().(suggestions.Suggestion)
+	suggestion := s.Selected().(suggestion.Suggestion)
 	start := s.adapter.Pos()
 	carets := s.ctrl.Carets()
 	if len(carets) != 1 {
@@ -144,7 +144,7 @@ func (s *suggestionList) apply() {
 	end := carets[0]
 	runes := s.ctrl.TextRunes()
 
-	if start < end {
+	if start <= end {
 		go s.applier.Apply(s.editor, input.Edit{
 			At:  start,
 			Old: runes[start:end],

--- a/suggestion/gocode.go
+++ b/suggestion/gocode.go
@@ -2,7 +2,7 @@
 // domain.  For more information, see <http://unlicense.org> or the
 // accompanying UNLICENSE file.
 
-package suggestions
+package suggestion
 
 import (
 	"bytes"

--- a/suggestion/suggestion.go
+++ b/suggestion/suggestion.go
@@ -2,7 +2,7 @@
 // domain.  For more information, see <http://unlicense.org> or the
 // accompanying UNLICENSE file.
 
-package suggestions
+package suggestion
 
 import "fmt"
 

--- a/suggestion/suggestion_adapter.go
+++ b/suggestion/suggestion_adapter.go
@@ -2,7 +2,7 @@
 // domain.  For more information, see <http://unlicense.org> or the
 // accompanying UNLICENSE file.
 
-package suggestions
+package suggestion
 
 import (
 	"math"


### PR DESCRIPTION
When deciding whether or not we can apply a suggestion, we used < when we should have
been using <=.  This meant that suggestions could only be completed when at least one
character had already been typed of the resulting word.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
