### PR TITLE
Expand textbox for inputting name of project

### DIFF
--- a/command/project/add.go
+++ b/command/project/add.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/nelsam/gxui"
+	"github.com/nelsam/gxui/math"
 	"github.com/nelsam/gxui/themes/basic"
 	"github.com/nelsam/vidar/command/fs"
 	"github.com/nelsam/vidar/commander/bind"
@@ -50,6 +51,7 @@ func (p *Add) Init(driver gxui.Driver, theme *basic.Theme) {
 	p.status = theme.CreateLabel()
 	p.path = fs.NewLocator(driver, theme, fs.Dirs)
 	p.name = theme.CreateTextBox()
+	p.name.SetDesiredWidth(math.MaxSize.W)
 	p.gopath = fs.NewLocator(driver, theme, fs.Dirs)
 }
 

--- a/command/project/find.go
+++ b/command/project/find.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/nelsam/gxui"
+	"github.com/nelsam/gxui/math"
 	"github.com/nelsam/vidar/commander/bind"
 	"github.com/nelsam/vidar/plugin/status"
 	"github.com/nelsam/vidar/setting"
@@ -34,6 +35,7 @@ func NewFind(theme gxui.Theme) *Find {
 	p := &Find{}
 	p.Theme = theme
 	p.name = theme.CreateTextBox()
+	p.name.SetDesiredWidth(math.MaxSize.W)
 	return p
 }
 


### PR DESCRIPTION
Current width of textbox can display small amount of symbols (8 with my preferences of font and size) that not very conveniently so I propose to expand it on full size.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [ ] Bug Fix
* [ ] New Feature
* [x] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [x] Windows
* [ ] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
