### PR TITLE
.travis.yml: remove go tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ os:
 
 go:
 - 1.13.x
-- tip
-
-matrix:
-  allow_failures:
-  - go: tip
 
 install:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; sudo apt-get install libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgl1-mesa-dev libxxf86vm-dev; fi


### PR DESCRIPTION
I added tip as an allowed failure so that we'd get something of a heads up if anything broke with
in-development versions of go.  Unfortunately, the 'allow failure' setting in travis does not
allow the build to complete until the allowed failures are finished - making this more counter-
productive than it's worth.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [ ] Bug Fix
* [ ] New Feature
* [x] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [ ] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
