### PR TITLE
modules: fix up vidar for working on modules

### DIFF
--- a/plugin/godef/godef.go
+++ b/plugin/godef/godef.go
@@ -10,7 +10,6 @@ package godef
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -109,16 +108,9 @@ func (g *Godef) Exec() error {
 	cmd.Stdin = bytes.NewBufferString(g.editor.Text())
 	errBuffer := &bytes.Buffer{}
 	cmd.Stderr = errBuffer
-	cmd.Env = []string{"PATH=" + os.Getenv("PATH")}
-	if proj.Gopath != "" {
-		cmd.Env[0] += string(os.PathListSeparator) + filepath.Join(proj.Gopath, "bin")
-		cmd.Env = append(cmd.Env, "GOPATH="+proj.Gopath)
-	}
+	cmd.Env = proj.Environ()
+	cmd.Dir = filepath.Dir(g.editor.Filepath())
 	output, err := cmd.Output()
-	if err != nil {
-		g.Err = fmt.Sprintf("godef error: %s", string(output))
-		return err
-	}
 	path, line, col, err := parseGodef(output)
 	if err != nil {
 		g.Err = err.Error()

--- a/setting/config/config.go
+++ b/setting/config/config.go
@@ -247,6 +247,18 @@ func convert(v reflect.Value, typ reflect.Type) reflect.Value {
 			res = reflect.Append(res, convert(v.Index(i), elemType))
 		}
 		return res
+	case reflect.Map:
+		if v.Kind() != reflect.Map {
+			return v
+		}
+		res := reflect.MakeMap(typ)
+		keyType := typ.Key()
+		elemType := typ.Elem()
+		iter := v.MapRange()
+		for iter.Next() {
+			res.SetMapIndex(convert(iter.Key(), keyType), convert(iter.Value(), elemType))
+		}
+		return res
 	default:
 		if !v.Type().ConvertibleTo(typ) {
 			return v


### PR DESCRIPTION
Go modules are in heavy use, for better or for worse.  We need to support them.
The project type had to change in the settings in order to track a host of
environment variables, especially since the GOPATH is no longer required.  This
forced changes to several plugins (e.g. goimports and godef), as well.

### Type

<!-- Please check mark (change [ ] to [x]) any of the following that apply to your PR. -->

* [x] Bug Fix
* [ ] New Feature
* [ ] Quality of Life Improvement

### Tests

<!-- Please check mark any testing you've done.  While this isn't always necessary to get
     your PR merged, it does help speed up the process. -->

I have tested locally against:
* [ ] Windows
* [x] linux
* [ ] OS X
* [ ] BSD

I have included automated tests:
* [ ] Unit tests
* [ ] Integration tests
* [ ] End to end tests
